### PR TITLE
[FE] 강의평이 비어있어도 보여주는 오류 수정

### DIFF
--- a/front/src/components/Lectures/Lectures.tsx
+++ b/front/src/components/Lectures/Lectures.tsx
@@ -51,7 +51,7 @@ const Lectures = ({
           subject,
           professor,
           score: data.averageRating,
-          details: data.data.split("\n"),
+          details: data.data.trim().split("\n"),
         });
 
         setError("none");


### PR DESCRIPTION
## Issue

- close #67 

## Description

- 강의평이 비어있어도 보여주는 오류 수정

## Check List

- [x] PR의 제목을 규칙에 맞게 작성
- [x] PR과 이슈 연결 완료
- [x] 적절한 담당자 및 라벨 설정
- [x] main 브랜치의 최신 상태를 반영하고 있는지 확인