### PR TITLE
[FE] 다크 모드의 초기 상태를 ThemeProvider에서 설정하게 수정

### DIFF
--- a/front/src/context/ThemeProvider.tsx
+++ b/front/src/context/ThemeProvider.tsx
@@ -1,4 +1,9 @@
-import { createContext, useState, type ReactNode } from "react";
+import {
+  createContext,
+  useState,
+  useLayoutEffect,
+  type ReactNode,
+} from "react";
 import { ThemeProvider as StyledProvider } from "styled-components";
 
 import { lightTheme, darkTheme } from "@/styles/Theme.ts";
@@ -15,6 +20,14 @@ interface ThemeProviderProps {
 export const ThemeProvider = ({ children }: ThemeProviderProps) => {
   const [theme, setTheme] = useState("light");
   const themeObject = theme === "light" ? lightTheme : darkTheme;
+
+  useLayoutEffect(() => {
+    if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      setTheme("dark");
+    } else {
+      setTheme("light");
+    }
+  }, []);
 
   return (
     <ThemeContext.Provider value={{ theme, setTheme }}>

--- a/front/src/hooks/useTheme.ts
+++ b/front/src/hooks/useTheme.ts
@@ -1,4 +1,4 @@
-import { useContext, useLayoutEffect } from "react";
+import { useContext } from "react";
 
 import { ThemeContext } from "@/context/ThemeProvider.tsx";
 
@@ -13,14 +13,6 @@ const useTheme = () => {
       setTheme("light");
     }
   };
-
-  useLayoutEffect(() => {
-    if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-      setTheme("dark");
-    } else {
-      setTheme("light");
-    }
-  }, []);
 
   return { theme, handleTheme };
 };


### PR DESCRIPTION
## Issue

- close #73 

## Description

- 다크 모드의 초기 상태를 ThemeProvider에서 설정하게 수정

## Check List

- [x] PR의 제목을 규칙에 맞게 작성
- [x] PR과 이슈 연결 완료
- [x] 적절한 담당자 및 라벨 설정
- [x] main 브랜치의 최신 상태를 반영하고 있는지 확인
